### PR TITLE
[NO-ISSUE] Fixed issue with FetchingProvider remounting children

### DIFF
--- a/src/lib/FetchingProvider.tsx
+++ b/src/lib/FetchingProvider.tsx
@@ -50,12 +50,12 @@ export interface FetchingProviderApi {
 
 type State = {
   translations: MessageSourceContextShape,
-  isFetching: boolean,
+  isFetched: boolean,
 };
 
 const initialState: State = {
   translations: {},
-  isFetching: false,
+  isFetched: false,
 };
 
 /**
@@ -73,12 +73,12 @@ export function FetchingProvider(props: FetchingProviderApi) {
     onFetchingError = noop,
   } = props;
 
-  const [{ translations, isFetching }, setState] = React.useState<State>(initialState);
+  const [{ translations, isFetched }, setState] = React.useState<State>(initialState);
 
   React.useEffect(() => {
     let isStillMounted = true;
 
-    setState(state => ({ ...state, isFetching: true }));
+    setState((state: State) => ({ ...state, isFetched: false }));
     onFetchingStart();
 
     fetch(url)
@@ -87,7 +87,7 @@ export function FetchingProvider(props: FetchingProviderApi) {
         if (isStillMounted) {
           setState({
             translations: transform(response),
-            isFetching: false,
+            isFetched: true,
           });
           onFetchingEnd();
         }
@@ -99,6 +99,6 @@ export function FetchingProvider(props: FetchingProviderApi) {
     };
   }, [url]); // re-fetch only when url changes
 
-  const shouldRenderSubtree = !blocking || (blocking && !isFetching);
+  const shouldRenderSubtree = !blocking || (blocking && isFetched);
   return <Provider value={translations}>{shouldRenderSubtree ? children : null}</Provider>;
 }


### PR DESCRIPTION
* There was an issue with FetchingProvider that it rendered it's
children initially, before fetching was started, then rendering null and
finally rendering children again after fetching. This happened when
blocking was set to true (which is default). This was causing multiple
mounts of children, affecting performance.
* The issue was caused by misuse of "isFetching" flag in rendering logic
since it was initially false, before fetching has even started.
* Replacing "isFetching" with "isFetched" is restoring original purpose
of "blocking" flag, since rendering should or shouldn't be blocked until
data is fetched, not while it is fetching as it was implemented so far.