### PR TITLE
Feature/fix app crashing or not rendering when translations not available

### DIFF
--- a/src/lib/FetchingProvider.test.tsx
+++ b/src/lib/FetchingProvider.test.tsx
@@ -64,7 +64,7 @@ describe('FetchingProvider', () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it('fetches text resources and inits an empty translation map if result is undefined and transform is noop', async () => {
+  it('fetches text resources and inits an empty translation map if result is undefined', async () => {
     // @ts-ignore
     global.fetch = jest.fn(() =>
       Promise.resolve({

--- a/src/lib/FetchingProvider.test.tsx
+++ b/src/lib/FetchingProvider.test.tsx
@@ -111,6 +111,28 @@ describe('FetchingProvider', () => {
     expect(onFetchingError).toHaveBeenCalledTimes(1);
   });
 
+  it('invokes defaultOnFetchingError lifecycle on network failure when onFetchingResult is noop', async () => {
+    const faultyFetch = jest.fn(() => Promise.reject(new Error('Failure')));
+    // @ts-ignore
+    global.fetch = faultyFetch;
+
+    function TestComponent() {
+      return (
+        <FetchingProvider url="http://your.website.uri/texts?lang=en">
+          <Spy />
+        </FetchingProvider>
+      );
+    }
+
+    const { getByText } = RTL.render(<TestComponent />);
+    const spyNode = await RTL.waitForElement(() => getByText('hello.world'));
+
+    expect(spyNode).toBeDefined();
+    expect(spyNode.innerHTML).toBe('hello.world');
+    // @ts-ignore
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it('mounts children only once', async () => {
     let timesChildrenAreMounted = 0;
     const increaseChildrenMountedNumber = () => {

--- a/src/lib/FetchingProvider.test.tsx
+++ b/src/lib/FetchingProvider.test.tsx
@@ -64,6 +64,31 @@ describe('FetchingProvider', () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
+  it('fetches text resources and inits an empty translation map if result is undefined and transform is noop', async () => {
+    // @ts-ignore
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve(undefined),
+      }),
+    );
+
+    function TestComponent() {
+      return (
+        <FetchingProvider url="http://any.uri/texts?lang=en">
+          <Spy />
+        </FetchingProvider>
+      );
+    }
+
+    const { getByText } = RTL.render(<TestComponent />);
+    const spyNode = await RTL.waitForElement(() => getByText('hello.world'));
+
+    expect(spyNode).toBeDefined();
+    expect(spyNode.innerHTML).toBe('hello.world');
+    // @ts-ignore
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it('fetches text resources when url prop changes', async () => {
     const transform = jest.fn(x => x);
     const onFetchingStart = jest.fn();

--- a/src/lib/FetchingProvider.test.tsx
+++ b/src/lib/FetchingProvider.test.tsx
@@ -64,7 +64,7 @@ describe('FetchingProvider', () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it('fetches text resources and inits an empty translation map if result is undefined', async () => {
+  it('fetches text resources and defaults to previous state if result is undefined', async () => {
     // @ts-ignore
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -123,27 +123,15 @@ describe('FetchingProvider', () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
-  it('invokes onFetchingError lifecycle on network failure', async () => {
+  it('invokes onFetchingError lifecycle and defaults to previous state on network failure', async () => {
     const onFetchingError = jest.fn();
-    const faultyFetch = jest.fn(() => Promise.reject(new Error('Failure')));
-    // @ts-ignore
-    global.fetch = faultyFetch;
-
-    RTL.render(<FetchingProvider url="http://any.uri/texts" onFetchingError={onFetchingError} children={null} />);
-    await RTL.wait(); // until fetch() rejects
-
-    expect(faultyFetch).toHaveBeenCalledTimes(1);
-    expect(onFetchingError).toHaveBeenCalledTimes(1);
-  });
-
-  it('invokes defaultOnFetchingError lifecycle on network failure when onFetchingResult is noop', async () => {
     const faultyFetch = jest.fn(() => Promise.reject(new Error('Failure')));
     // @ts-ignore
     global.fetch = faultyFetch;
 
     function TestComponent() {
       return (
-        <FetchingProvider url="http://your.website.uri/texts?lang=en">
+        <FetchingProvider url="http://your.website.uri/texts?lang=en" onFetchingError={onFetchingError}>
           <Spy />
         </FetchingProvider>
       );
@@ -154,8 +142,8 @@ describe('FetchingProvider', () => {
 
     expect(spyNode).toBeDefined();
     expect(spyNode.innerHTML).toBe('hello.world');
-    // @ts-ignore
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(faultyFetch).toHaveBeenCalledTimes(1);
+    expect(onFetchingError).toHaveBeenCalledTimes(1);
   });
 
   it('mounts children only once', async () => {

--- a/src/lib/FetchingProvider.tsx
+++ b/src/lib/FetchingProvider.tsx
@@ -77,6 +77,12 @@ export function FetchingProvider(props: FetchingProviderApi) {
 
   React.useEffect(() => {
     let isStillMounted = true;
+    const defaultOnFetchingError = () => {
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('Failed to fetch translations. Setting an empty translation map.');
+      }
+      setState({ translations: {}, isFetched: true });
+    };
 
     setState((state: State) => ({ ...state, isFetched: false }));
     onFetchingStart();
@@ -92,7 +98,7 @@ export function FetchingProvider(props: FetchingProviderApi) {
           onFetchingEnd();
         }
       })
-      .catch(onFetchingError);
+      .catch(e => (onFetchingError !== noop ? onFetchingError(e) : defaultOnFetchingError()));
 
     return () => {
       isStillMounted = false;

--- a/src/lib/FetchingProvider.tsx
+++ b/src/lib/FetchingProvider.tsx
@@ -84,7 +84,7 @@ export function FetchingProvider(props: FetchingProviderApi) {
 
   React.useEffect(() => {
     let isStillMounted = true;
-    const defaultOnFetchingError = () => {
+    const initEmptyTranslationMap = () => {
       logTranslationsNOK();
       setState({ translations: {}, isFetched: true });
     };
@@ -103,7 +103,7 @@ export function FetchingProvider(props: FetchingProviderApi) {
           onFetchingEnd();
         }
       })
-      .catch(e => (onFetchingError !== noop ? onFetchingError(e) : defaultOnFetchingError()));
+      .catch(e => (onFetchingError !== noop ? onFetchingError(e) : initEmptyTranslationMap()));
 
     return () => {
       isStillMounted = false;

--- a/src/lib/FetchingProvider.tsx
+++ b/src/lib/FetchingProvider.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { MessageSourceContextShape, Provider } from './MessageSourceContext';
 import { logTranslationsNOK } from './utils';
 
+const identity = (x: any): any => x;
 const identityWithFalsenessCheck = (x: any) => {
   if (!!x) {
     return x;
@@ -74,7 +75,7 @@ export function FetchingProvider(props: FetchingProviderApi) {
     url,
     children,
     blocking = true,
-    transform = identityWithFalsenessCheck,
+    transform = identity,
     onFetchingStart = noop,
     onFetchingEnd = noop,
     onFetchingError = noop,
@@ -94,10 +95,12 @@ export function FetchingProvider(props: FetchingProviderApi) {
 
     fetch(url)
       .then(r => r.json())
-      .then(response => {
+      .then(rawTranslations => transform(rawTranslations))
+      .then(transformedTranslations => identityWithFalsenessCheck(transformedTranslations))
+      .then(checkedTranslations => {
         if (isStillMounted) {
           setState({
-            translations: transform(response),
+            translations: checkedTranslations,
             isFetched: true,
           });
           onFetchingEnd();

--- a/src/lib/FetchingProvider.tsx
+++ b/src/lib/FetchingProvider.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
 import { MessageSourceContextShape, Provider } from './MessageSourceContext';
+import { logTranslationsNOK } from './utils';
 
-const identityWithFalsenessCheck = (x: any) => (!!x ? x : {});
+const identityWithFalsenessCheck = (x: any) => {
+  if (!!x) {
+    return x;
+  }
+  logTranslationsNOK();
+  return {};
+};
 const noop = () => {};
 
 export interface FetchingProviderApi {
@@ -78,9 +85,7 @@ export function FetchingProvider(props: FetchingProviderApi) {
   React.useEffect(() => {
     let isStillMounted = true;
     const defaultOnFetchingError = () => {
-      if (process.env.NODE_ENV !== 'production') {
-        console.log('Failed to fetch translations. Setting an empty translation map.');
-      }
+      logTranslationsNOK();
       setState({ translations: {}, isFetched: true });
     };
 

--- a/src/lib/FetchingProvider.tsx
+++ b/src/lib/FetchingProvider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { MessageSourceContextShape, Provider } from './MessageSourceContext';
 
-const identity = (x: any): any => x;
+const identityWithFalsenessCheck = (x: any) => (!!x ? x : {});
 const noop = () => {};
 
 export interface FetchingProviderApi {
@@ -67,7 +67,7 @@ export function FetchingProvider(props: FetchingProviderApi) {
     url,
     children,
     blocking = true,
-    transform = identity,
+    transform = identityWithFalsenessCheck,
     onFetchingStart = noop,
     onFetchingEnd = noop,
     onFetchingError = noop,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,6 +20,6 @@ export const normalizeKeyPrefix = (keyPrefix: string) =>
  */
 export const logTranslationsNOK = () => {
   if (process.env.NODE_ENV !== 'production') {
-    console.log('Failed to get proper translations. Setting an empty translation map.');
+    console.log('[react-message-source] Failed to get proper translations. Setting an empty translation map.');
   }
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,3 +14,12 @@ const endsWith = (str: string, suffix: string) => str.indexOf(suffix, str.length
  */
 export const normalizeKeyPrefix = (keyPrefix: string) =>
   keyPrefix.length > 0 && !endsWith(keyPrefix, '.') ? `${keyPrefix}.` : keyPrefix;
+
+/**
+ * Logs that there was an error in retrieving the translation map.
+ */
+export const logTranslationsNOK = () => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('Failed to get proper translations. Setting an empty translation map.');
+  }
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,12 +14,3 @@ const endsWith = (str: string, suffix: string) => str.indexOf(suffix, str.length
  */
 export const normalizeKeyPrefix = (keyPrefix: string) =>
   keyPrefix.length > 0 && !endsWith(keyPrefix, '.') ? `${keyPrefix}.` : keyPrefix;
-
-/**
- * Logs that there was an error in retrieving the translation map.
- */
-export const logTranslationsNOK = () => {
-  if (process.env.NODE_ENV !== 'production') {
-    console.log('[react-message-source] Failed to get proper translations. Setting an empty translation map.');
-  }
-};


### PR DESCRIPTION
## Summary
Fixes #25 

Issue can be split in 2 parts:

1. App crashes when an invalid response is returned for the translations [`null`, `undefined`]. This causes the library to query an undefined variable resulting in the crash. To remedy this, an `identityWithFalsenessCheck` function was added that gets executed after the normal `transform` function does its job. By this time we should have a translation map ready to go, and this function will check if thats the case and will return an empty map if not. The library will continue to function returning text keys after that.

2. App prevents sub tree from rendering when there is a network error. To remedy this, `initEmptyTranslationMap` will get executed when a default `onFetchingError` is not provided that will init an empty translation map and the library will function properly after that. It checks for a provided `onFetchingError` first since likely projects have adapted to this use case and are handling it that way.

Did a quick manual test as well and we are now getting an app with text keys rather than a crash or a no render.

I am not 100% sure which one of these this issue is specifically targeting, but we can revert either one of them if needed.

