### PR TITLE
Allow React 17 as peer dependency for NPM v7 builds not to fail.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.10",
-    "react": "^16.8.0"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@testing-library/react": "9.1.4",


### PR DESCRIPTION
SInce React v17 has not introduced any breaking changes this library can use v17 without any issue.